### PR TITLE
chore!: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
     }
   },
@@ -124,27 +125,26 @@
   },
   "scripts": {
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js",
-    "build": "tsc",
-    "pretest": "npm run build",
-    "test": "aegir test -f ./dist/test",
-    "test:chrome": "npm run test -- -t browser --cov",
-    "test:chrome-webworker": "npm run test -- -t webworker",
-    "test:firefox": "npm run test -- -t browser -- --browser firefox",
-    "test:firefox-webworker": "npm run test -- -t webworker -- --browser firefox",
-    "test:node": "npm run test -- -t node --cov",
-    "test:electron-main": "npm run test -- -t electron-main",
-    "release": "semantic-release"
+    "dep-check": "aegir dep-check",
+    "build": "aegir build",
+    "test": "aegir test",
+    "test:chrome": "aegir test -t browser --cov",
+    "test:chrome-webworker": "aegir test -t webworker",
+    "test:firefox": "aegir test -t browser -- --browser firefox",
+    "test:firefox-webworker": "aegir test -t webworker -- --browser firefox",
+    "test:node": "aegir test -t node --cov",
+    "test:electron-main": "aegir test -t electron-main",
+    "release": "aegir release"
   },
   "dependencies": {
     "it-map": "^1.0.6",
-    "it-pushable": "^2.0.1",
+    "it-pushable": "^3.0.0",
     "it-reader": "^5.0.0",
     "it-stream-types": "^1.0.4",
     "p-defer": "^4.0.0"
   },
   "devDependencies": {
-    "aegir": "^36.1.3",
+    "aegir": "^37.2.0",
     "it-all": "^1.0.6",
     "it-pair": "^2.0.2",
     "it-pipe": "^2.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export interface Handshake {
 
 // Convert a duplex stream into a reader and writer and rest stream
 export function handshake (stream: Duplex<Uint8Array>): Handshake {
-  const writer = pushable<Uint8Array>() // Write bytes on demand to the sink
+  const writer = pushable() // Write bytes on demand to the sink
   const source = reader(stream.source) // Read bytes on demand from the source
 
   // Waits for a source to be passed to the rest stream's sink

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'aegir/utils/chai.js'
+import { expect } from 'aegir/chai'
 import { handshake } from '../src/index.js'
 import { duplexPair } from 'it-pair/duplex'
 import { pipe } from 'it-pipe'


### PR DESCRIPTION
Updates deps including it-pushable which now defaults to accepting `Uint8Array`s similar to node streams.

BREAKING CHANGE: it-pushable types are exported as part of the public api and the default type isn't generic any more