### PR TITLE
fix: remove unnecessary slice

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export function handshake (stream: Duplex<Uint8Array>): Handshake {
       sourcePromise.resolve(source)
       return await sinkPromise
     },
-    source: map(source, bl => bl.slice())
+    source: source
   }
 
   return {


### PR DESCRIPTION
There shouldn't be a need to slice each element in the source, and doing so unnecessarily comes with performance costs.