### PR TITLE
feat: support Uint8ArrayList

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "it-map": "^1.0.6",
     "it-pushable": "^3.0.0",
     "it-reader": "^6.0.1",
     "it-stream-types": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
     "it-pushable": "^3.0.0",
     "it-reader": "^6.0.1",
     "it-stream-types": "^1.0.4",
-    "p-defer": "^4.0.0"
+    "p-defer": "^4.0.0",
+    "uint8arraylist": "^2.0.0"
   },
   "devDependencies": {
     "aegir": "^37.2.0",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "it-pushable": "^3.0.0",
+    "it-pushable": "^3.1.0",
     "it-reader": "^6.0.1",
     "it-stream-types": "^1.0.4",
     "p-defer": "^4.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export interface Handshake<T extends Uint8Array|Uint8ArrayList> {
 
 // Convert a duplex stream into a reader and writer and rest stream
 export function handshake<T extends Uint8Array|Uint8ArrayList> (stream: Duplex<T>): Handshake<T> {
-  const writer = pushable<T>({ objectMode: true }) // Write bytes on demand to the sink
+  const writer = pushable<T>() // Write bytes on demand to the sink
   const source = reader(stream.source) // Read bytes on demand from the source
 
   // Waits for a source to be passed to the rest stream's sink

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import type { Duplex, Source } from 'it-stream-types'
 import type { Pushable } from 'it-pushable'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
-export interface Handshake<T extends Uint8Array|Uint8ArrayList> {
+export interface Handshake<T extends Uint8Array | Uint8ArrayList = Uint8Array> {
   reader: Reader
   writer: Pushable<T>
   stream: Duplex<T>
@@ -15,7 +15,7 @@ export interface Handshake<T extends Uint8Array|Uint8ArrayList> {
 }
 
 // Convert a duplex stream into a reader and writer and rest stream
-export function handshake<T extends Uint8Array|Uint8ArrayList> (stream: Duplex<T>): Handshake<T> {
+export function handshake<T extends Uint8Array | Uint8ArrayList = Uint8Array> (stream: Duplex<T>): Handshake<T> {
   const writer = pushable<T>() // Write bytes on demand to the sink
   const source = reader(stream.source) // Read bytes on demand from the source
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,26 @@
 import { Reader, reader } from 'it-reader'
 import { pushable } from 'it-pushable'
 import defer from 'p-defer'
-import map from 'it-map'
 import type { Duplex, Source } from 'it-stream-types'
 import type { Pushable } from 'it-pushable'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
-export interface Handshake {
+export interface Handshake<T extends Uint8Array|Uint8ArrayList> {
   reader: Reader
-  writer: Pushable<Uint8Array>
-  stream: Duplex<Uint8Array>
-  rest: () => Source<Uint8Array>
-  write: (data: Uint8Array) => void
-  read: () => Promise<Uint8Array | undefined>
+  writer: Pushable<T>
+  stream: Duplex<T>
+  rest: () => Source<T>
+  write: (data: T) => void
+  read: () => Promise<Uint8ArrayList | undefined>
 }
 
 // Convert a duplex stream into a reader and writer and rest stream
-export function handshake (stream: Duplex<Uint8Array>): Handshake {
-  const writer = pushable() // Write bytes on demand to the sink
+export function handshake<T extends Uint8Array|Uint8ArrayList> (stream: Duplex<T>): Handshake<T> {
+  const writer = pushable<T>({ objectMode: true }) // Write bytes on demand to the sink
   const source = reader(stream.source) // Read bytes on demand from the source
 
   // Waits for a source to be passed to the rest stream's sink
-  const sourcePromise = defer<Source<Uint8Array>>()
+  const sourcePromise = defer<Source<T>>()
   let sinkErr: Error
 
   const sinkPromise = stream.sink((async function * () {
@@ -33,7 +33,7 @@ export function handshake (stream: Duplex<Uint8Array>): Handshake {
     sinkErr = err
   })
 
-  const rest: Duplex<Uint8Array> = {
+  const rest: Duplex<T> = {
     sink: async source => {
       if (sinkErr != null) {
         return await Promise.reject(sinkErr)
@@ -42,7 +42,7 @@ export function handshake (stream: Duplex<Uint8Array>): Handshake {
       sourcePromise.resolve(source)
       return await sinkPromise
     },
-    source: map(source, bl => bl.slice())
+    source: stream.source
   }
 
   return {
@@ -55,7 +55,7 @@ export function handshake (stream: Duplex<Uint8Array>): Handshake {
       const res = await source.next()
 
       if (res.value != null) {
-        return res.value.slice()
+        return res.value
       }
     }
   }


### PR DESCRIPTION
- add type support for streams of Uint8ArrayLists
- `rest`  returns unwrapped source
- `read` returns Uint8ArrayList which is breaking change, should I subArray into Uint8Array?
- switched pushable to objectMode until it-pushable supports Uint8ArrayList natively